### PR TITLE
Package help was renamed to htmlhelp in FreeDOS 1.2 tree.

### DIFF
--- a/src/dosemu-downloaddos
+++ b/src/dosemu-downloaddos
@@ -19,7 +19,7 @@ FREEDOS_BASE_URL = FREEDOS_DEFAULT_MIRROR + '/distributions'
 FREEDOS11_URL = FREEDOS_BASE_URL + '/1.1'
 FREEDOS12_URL = FREEDOS_BASE_URL + '/1.2'
 FREEDOS_USERSPACE_TOOLS = [ 'assign', 'attrib', 'choice', 'comp', 'debug', 'display', 'edit', 'edlin', 'fc',
-                    'find', 'format', 'help', 'label', 'mem', 'mode', 'nansi', 'share', 'sort', 'swsubst', 'tree']
+                    'find', 'format', 'help', 'htmlhelp', 'label', 'mem', 'mode', 'nansi', 'share', 'sort', 'swsubst', 'tree']
 FREEDOS_ARCHIVES_KERNEL_COMMAND = [ 'kernel', 'command' ]
 FREEDOS_ARCHIVES_EXTRA = ['defrag', 'deltree', 'diskcomp', 'diskcopy', 'exe2bin', 'more', 'move', 'replace',
                      'share', 'shsucdx', 'xcopy']

--- a/src/dosemu-installfreedos
+++ b/src/dosemu-installfreedos
@@ -11,7 +11,7 @@ import zlib
 from pathlib import Path
 
 USERSPACE_TOOLS = [ 'assign', 'attrib', 'choice', 'comp', 'debug', 'display', 'edit', 'edlin', 'fc',
-                    'find', 'format', 'help', 'label', 'mem', 'mode', 'nansi', 'share', 'sort', 'swsubst', 'tree']
+                    'find', 'format', 'help', 'htmlhelp', 'label', 'mem', 'mode', 'nansi', 'share', 'sort', 'swsubst', 'tree']
 
 def extract_zipfile_entry(archive, zipinfo, output_filename):
     if Path(output_filename).exists():


### PR DESCRIPTION
See https://sourceforge.net/p/freedos/mailman/message/37259131/

Note this also requires the commit from the other PR to work properly.