### PR TITLE
Multiple urls

### DIFF
--- a/src/dosemu-downloaddos
+++ b/src/dosemu-downloaddos
@@ -213,7 +213,7 @@ Either a name should contain \"Disk ? of x\" or \"diskx\" where 1 is the first d
 The destination directory will contain all files from all disk images.""")
 parser.add_argument("-l", "--list", help="List available DOS variants", action="store_true")
 parser.add_argument("-o", "--os", help="Download the specified DOS", type=str)
-parser.add_argument("-c", "--custom",    help="Download specified disk/file set, requires a destination directory", type=str)
+parser.add_argument("-c", "--custom",    help="Download specified disk/file set, requires a destination directory", nargs='+', type=str)
 parser.add_argument("-d", "--destination", help="Specify/override the destination directory", type=str)
 parser.add_argument("-s", "--sha256sum", help="Specify one or more sha256sum(s)", nargs='+', type=str)
 
@@ -234,11 +234,14 @@ if args.os:
     download_dos(dos_to_download, destination)
 
 if args.custom and args.destination:
-    url = args.custom
+    urls = args.custom
     destination = args.destination
     os.makedirs(destination, exist_ok=True)
     if not os.listdir(destination):
-        download_and_process(derive_url_list(url), destination, args.sha256sum if args.sha256sum else [])
+        if len(urls) == 1:
+            download_and_process(derive_url_list(urls[0]), destination, args.sha256sum if args.sha256sum else [])
+        else:
+            download_and_process(urls, destination, args.sha256sum if args.sha256sum else [])
     else:
         if args.sha256sum and not list(Path(destination).glob('*.sys')):
             for i, file in enumerate(Path(destination).iterdir()):


### PR DESCRIPTION
This allows specifying multiple URLs whereas previously only one URL could be specified.
This is required for the install-win31 script to fully work.
This script should probably be split too.