### PR TITLE
Bump Standards-Version to 4.1.5

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: install-freedos
 Section: contrib/otherosfs
 Priority: optional
 Maintainer: Stas Sergeev <stsp@users.sourceforge.net>
-Standards-Version: 3.9.7
+Standards-Version: 4.1.5
 Build-Depends:
     make,
     debhelper (>= 9~)


### PR DESCRIPTION
The package installs files in /usr/libexec, which is allowed since Policy 4.1.5.