### PR TITLE
command.zip was renamed to freecom.zip for FreeDOS 1.2, adjust the script to accomodate

### DIFF
--- a/src/dosemu-downloaddos
+++ b/src/dosemu-downloaddos
@@ -20,7 +20,7 @@ FREEDOS11_URL = FREEDOS_BASE_URL + '/1.1'
 FREEDOS12_URL = FREEDOS_BASE_URL + '/1.2'
 FREEDOS_USERSPACE_TOOLS = [ 'assign', 'attrib', 'choice', 'comp', 'debug', 'display', 'edit', 'edlin', 'fc',
                     'find', 'format', 'htmlhelp', 'label', 'mem', 'mode', 'nansi', 'share', 'sort', 'swsubst', 'tree']
-FREEDOS_ARCHIVES_KERNEL_COMMAND = [ 'kernel', 'command' ]
+FREEDOS_ARCHIVES_KERNEL_COMMAND = [ 'kernel', 'command', 'freecom' ]
 FREEDOS_ARCHIVES_EXTRA = ['defrag', 'deltree', 'diskcomp', 'diskcopy', 'exe2bin', 'more', 'move', 'replace',
                      'share', 'shsucdx', 'xcopy']
 FREEDOS_UNIXLIKE_ARCHIVES = ['touch']
@@ -114,7 +114,10 @@ def download_FREEDOS_USERSPACE_ARCHIVES(freedos_url, destination):
 def download_FREEDOS_FULL_ARCHIVES(freedos_url, destination):
     print('Downloading FreeDOS kernel and FreeCOM...')
     for filename in FREEDOS_ARCHIVES_KERNEL_COMMAND:
-        download_file(freedos_url + '/repos/base/' + filename + '.zip', destination)
+        try:
+            download_file(freedos_url + '/repos/base/' + filename + '.zip', destination)
+        except urllib.error.HTTPError:
+            print('WARNING: The chosen version of FreeDOS does not contain ' + filename + '!')
     print('Downloading extra FreeDOS userspace tools')
     download_FREEDOS_USERSPACE_ARCHIVES(freedos_url, destination)
 

--- a/src/dosemu-setupfreedos
+++ b/src/dosemu-setupfreedos
@@ -35,6 +35,8 @@ def extract_zipfile_entry(archive, zipinfo, output_filename):
 def extract_freedos_archives(source, drive_root, variant):
     for filename in Path(source).glob('*.zip'):
         if variant == 'userspace':
+            if str(filename).endswith('freecom.zip'):
+                continue
             if str(filename).endswith('command.zip'):
                 continue
             if str(filename).endswith('kernel.zip'):


### PR DESCRIPTION
Note that FreeDOS 1.1 still has `command.zip` so the script can deal with either now. (Also mirrors with older 1.2 copies would work.)