### PR TITLE
setup: Ensure the parent directory exists when extracting

### DIFF
--- a/src/dosemu-downloaddos
+++ b/src/dosemu-downloaddos
@@ -4,12 +4,10 @@ import argparse
 import hashlib
 import os
 import re
-import shutil
-import subprocess
 import sys
+import time
 import urllib.parse
 import urllib.request
-import zipfile
 from pathlib import Path
 from tqdm import tqdm
 
@@ -199,22 +197,28 @@ def download_dos(dos_flavour, destination):
 
     print('Downloading done')
 
-def urls_ok(urls, verbose=False):
+def urls_ok(urls, verbose=False, timeout=10, retries=3, retry_delay=1):
     failures = 0
 
     def test_url(url):
-        try:
-            req = urllib.request.Request(url, method="HEAD")
-            resp = urllib.request.urlopen(req)
-            a = resp.read()
-            if (verbose):
-                print("INFO: Checked (%s)" % url)
-
-        except urllib.error.HTTPError:
-            print("FAIL: Does not exist (%s)" % url)
-            return False
-
-        return True
+        for attempt in range(1, retries + 1):
+            try:
+                req = urllib.request.Request(url, method="HEAD")
+                resp = urllib.request.urlopen(req, timeout=timeout)
+                resp.read()
+                if verbose:
+                    print("INFO: Checked (%s)" % url)
+                return True
+            except urllib.error.HTTPError:
+                print("FAIL: Does not exist (%s)" % url)
+                return False
+            except Exception as e:
+                if attempt == retries:
+                    print("FAIL: Error on attempt %d: %s (%s)" % (attempt, e, url))
+                    return False
+                if verbose:
+                    print("WARN: Attempt %d failed for %s, retrying..." % (attempt, url))
+                time.sleep(retry_delay)
 
     for url in urls:
         if not test_url(url):
@@ -250,7 +254,7 @@ if args.test:
             freedos13_boot + freedos13_userspace +
             freedos14_boot + freedos14_userspace
            )
-    if not urls_ok(urls, True):
+    if not urls_ok(urls, verbose=True, timeout=20):
         sys.exit(1)
     sys.exit(0)
 

--- a/src/dosemu-setupfreedos
+++ b/src/dosemu-setupfreedos
@@ -63,12 +63,13 @@ def extract_freedos_archives(source, drive_root, variant):
                 filename = entry.filename.lower()
                 if filename.startswith('packages/') or filename.startswith('source/') or filename == 'bin/kernl86.sys' or filename == 'bin/kernl386.sys':
                     continue
-                elif entry.is_dir():
-                    output_filename = os.path.join(drive_root, filename)
-                    os.makedirs(output_filename, exist_ok=True)
+
+                path = Path(drive_root) / filename
+                if entry.is_dir():
+                    path.mkdir(parents=True, exist_ok=True)
                 else:
-                    output_filename = os.path.join(drive_root, filename)
-                    extract_zipfile_entry(archive, entry, output_filename)
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    extract_zipfile_entry(archive, entry, path)
 
 def create_symlink(source, destination):
     if Path(destination).is_file():


### PR DESCRIPTION
It seems that when reading the zip archives from FreeDOS there are entries such as 'bin/file.exe' which will need the parent directories creating. Currently the extraction only creates directories if the entry is marked as a directory. Since extraction used to work, I can only imagine that in the past the archive would have had a preceding directory entry called 'bin'.